### PR TITLE
♻️ Refactor filesystem to remove enum access style

### DIFF
--- a/srlearn/base.py
+++ b/srlearn/base.py
@@ -172,7 +172,7 @@ class BaseBoostedRelationalModel:
         check_is_fitted(self, "estimators_")
 
         with open(
-            self.file_system.files.BRDNS_DIR.value.joinpath(
+            self.file_system.files.BRDNS_DIR.joinpath(
                 "{0}.model".format(self.target)
             ),
             "r",
@@ -264,10 +264,10 @@ class BaseBoostedRelationalModel:
         # Currently allocates the File System.
         self._check_params()
 
-        self.file_system.files.TREES_DIR.value.mkdir(parents=True)
+        self.file_system.files.TREES_DIR.mkdir(parents=True)
 
         with open(
-            self.file_system.files.BRDNS_DIR.value.joinpath(
+            self.file_system.files.BRDNS_DIR.joinpath(
                 "{0}.model".format(self.target)
             ),
             "w",
@@ -276,7 +276,7 @@ class BaseBoostedRelationalModel:
 
         for i, _tree in enumerate(_estimators):
             with open(
-                self.file_system.files.TREES_DIR.value.joinpath(
+                self.file_system.files.TREES_DIR.joinpath(
                     "{0}Tree{1}.tree".format(self.target, i)
                 ),
                 "w",
@@ -309,7 +309,7 @@ class BaseBoostedRelationalModel:
         dotfiles = []
         for i in range(self.n_estimators):
             with open(
-                self.file_system.files.DOT_DIR.value.joinpath(
+                self.file_system.files.DOT_DIR.joinpath(
                     "WILLTreeFor_" + self.target + str(i) + ".dot"
                 )
             ) as _fh:

--- a/srlearn/rdn.py
+++ b/srlearn/rdn.py
@@ -133,7 +133,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
 
         # Write the background to file.
         self.background.write(
-            filename="train", location=self.file_system.files.TRAIN_DIR.value
+            filename="train", location=self.file_system.files.TRAIN_DIR
         )
 
         if isinstance(database, tuple):
@@ -145,19 +145,19 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
 
         # Write the data to files.
         database.write(
-            filename="train", location=self.file_system.files.TRAIN_DIR.value
+            filename="train", location=self.file_system.files.TRAIN_DIR
         )
 
         if self.solver == "BoostSRL":
-            _jar = str(self.file_system.files.BOOSTSRL_BACKEND.value)
+            _jar = str(self.file_system.files.BOOSTSRL_BACKEND)
         else:
-            _jar = str(self.file_system.files.SRLBOOST_BACKEND.value)
+            _jar = str(self.file_system.files.SRLBOOST_BACKEND)
 
         _CALL = (
             "java -jar "
             + _jar
             + " -l -train "
-            + str(self.file_system.files.TRAIN_DIR.value)
+            + str(self.file_system.files.TRAIN_DIR)
             + " -target "
             + self.target
             + " -trees "
@@ -165,7 +165,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
             + " -negPosRatio "
             + str(self.neg_pos_ratio)
             + " > "
-            + str(self.file_system.files.TRAIN_LOG.value)
+            + str(self.file_system.files.TRAIN_LOG)
         )
 
         # Call the constructed command.
@@ -175,7 +175,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
         _estimators = []
         for _tree_number in range(self.n_estimators):
             with open(
-                self.file_system.files.TREES_DIR.value.joinpath(
+                self.file_system.files.TREES_DIR.joinpath(
                     "{0}Tree{1}.tree".format(self.target, _tree_number)
                 )
             ) as _fh:
@@ -203,38 +203,38 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
 
         # Write the background to file.
         self.background.write(
-            filename="test", location=self.file_system.files.TEST_DIR.value
+            filename="test", location=self.file_system.files.TEST_DIR
         )
 
         # Write the data to files.
-        database.write(filename="test", location=self.file_system.files.TEST_DIR.value)
+        database.write(filename="test", location=self.file_system.files.TEST_DIR)
 
         if self.solver == "BoostSRL":
-            _jar = str(self.file_system.files.BOOSTSRL_BACKEND.value)
+            _jar = str(self.file_system.files.BOOSTSRL_BACKEND)
         else:
-            _jar = str(self.file_system.files.SRLBOOST_BACKEND.value)
+            _jar = str(self.file_system.files.SRLBOOST_BACKEND)
 
         _CALL = (
             "java -jar "
             + _jar
             + " -i -test "
-            + str(self.file_system.files.TEST_DIR.value)
+            + str(self.file_system.files.TEST_DIR)
             + " -model "
-            + str(self.file_system.files.MODELS_DIR.value)
+            + str(self.file_system.files.MODELS_DIR)
             + " -target "
             + self.target
             + " -trees "
             + str(self.n_estimators)
             + " -aucJarPath "
-            + str(self.file_system.files.AUC_JAR.value)
+            + str(self.file_system.files.AUC_JAR)
             + " > "
-            + str(self.file_system.files.TEST_LOG.value)
+            + str(self.file_system.files.TEST_LOG)
         )
 
         self._call_shell_command(_CALL)
 
         # Read the threshold
-        with open(self.file_system.files.TEST_LOG.value, "r") as _fh:
+        with open(self.file_system.files.TEST_LOG, "r") as _fh:
             _threshold = re.findall("% Threshold = \\d*.\\d*", _fh.read())
         self.threshold_ = float(_threshold[0].split(" = ")[1])
 
@@ -255,7 +255,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
         self._run_inference(database)
 
         # Collect the classifications.
-        _results_db = self.file_system.files.TEST_DIR.value.joinpath(
+        _results_db = self.file_system.files.TEST_DIR.joinpath(
             "results_" + self.target + ".db"
         )
         _classes, _results = np.loadtxt(
@@ -292,7 +292,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
 
         self._run_inference(database)
 
-        _results_db = self.file_system.files.TEST_DIR.value.joinpath(
+        _results_db = self.file_system.files.TEST_DIR.joinpath(
             "results_" + self.target + ".db"
         )
         _classes, _results = np.loadtxt(
@@ -477,7 +477,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
 
         # Write the background to file.
         self.background.write(
-            filename="train", location=self.file_system.files.TRAIN_DIR.value
+            filename="train", location=self.file_system.files.TRAIN_DIR
         )
 
         if isinstance(database, tuple):
@@ -489,19 +489,19 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
 
         # Write the data to files.
         database.write(
-            filename="train", location=self.file_system.files.TRAIN_DIR.value
+            filename="train", location=self.file_system.files.TRAIN_DIR
         )
 
         if self.solver == "BoostSRL":
-            _jar = str(self.file_system.files.BOOSTSRL_BACKEND.value)
+            _jar = str(self.file_system.files.BOOSTSRL_BACKEND)
         else:
-            _jar = str(self.file_system.files.SRLBOOST_BACKEND.value)
+            _jar = str(self.file_system.files.SRLBOOST_BACKEND)
 
         _CALL = (
             "java -jar "
             + _jar
             + " -reg -l -train "
-            + str(self.file_system.files.TRAIN_DIR.value)
+            + str(self.file_system.files.TRAIN_DIR)
             + " -target "
             + self.target
             + " -trees "
@@ -509,7 +509,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
             + " -negPosRatio "
             + str(self.neg_pos_ratio)
             + " > "
-            + str(self.file_system.files.TRAIN_LOG.value)
+            + str(self.file_system.files.TRAIN_LOG)
         )
 
         # Call the constructed command.
@@ -519,7 +519,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
         _estimators = []
         for _tree_number in range(self.n_estimators):
             with open(
-                self.file_system.files.TREES_DIR.value.joinpath(
+                self.file_system.files.TREES_DIR.joinpath(
                     "{0}Tree{1}.tree".format(self.target, _tree_number)
                 )
             ) as _fh:
@@ -540,7 +540,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
 
         # Write the background to file.
         self.background.write(
-            filename="test", location=self.file_system.files.TEST_DIR.value
+            filename="test", location=self.file_system.files.TEST_DIR
         )
 
         if isinstance(database, tuple):
@@ -551,28 +551,28 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
             database = _db
 
         # Write the data to files.
-        database.write(filename="test", location=self.file_system.files.TEST_DIR.value)
+        database.write(filename="test", location=self.file_system.files.TEST_DIR)
 
         if self.solver == "BoostSRL":
-            _jar = str(self.file_system.files.BOOSTSRL_BACKEND.value)
+            _jar = str(self.file_system.files.BOOSTSRL_BACKEND)
         else:
-            _jar = str(self.file_system.files.SRLBOOST_BACKEND.value)
+            _jar = str(self.file_system.files.SRLBOOST_BACKEND)
 
         _CALL = (
             "java -jar "
             + _jar
             + " -reg -i -test "
-            + str(self.file_system.files.TEST_DIR.value)
+            + str(self.file_system.files.TEST_DIR)
             + " -model "
-            + str(self.file_system.files.MODELS_DIR.value)
+            + str(self.file_system.files.MODELS_DIR)
             + " -target "
             + self.target
             + " -trees "
             + str(self.n_estimators)
             + " -aucJarPath "
-            + str(self.file_system.files.AUC_JAR.value)
+            + str(self.file_system.files.AUC_JAR)
             + " > "
-            + str(self.file_system.files.TEST_LOG.value)
+            + str(self.file_system.files.TEST_LOG)
         )
 
         self._call_shell_command(_CALL)
@@ -594,7 +594,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
         self._run_inference(database)
 
         # Collect the classifications.
-        _results_db = self.file_system.files.TEST_DIR.value.joinpath(
+        _results_db = self.file_system.files.TEST_DIR.joinpath(
             "results_" + self.target + ".db"
         )
         _pred, _true = np.loadtxt(

--- a/srlearn/system_manager.py
+++ b/srlearn/system_manager.py
@@ -2,8 +2,6 @@
 
 """Handler for file system operations on behalf of BoostSRL."""
 
-from enum import Enum
-from enum import unique
 import pathlib
 import shutil
 import os
@@ -77,6 +75,27 @@ def reset(soft=False):
     return []
 
 
+class BoostSRLFiles:
+    """Pointers to all file locations required by BoostSRL
+
+    After initialization, all of these should be constant.
+    """
+
+    def __init__(self, directory, here) -> None:
+        self.DIRECTORY = directory
+        self.BOOSTSRL_BACKEND = here.joinpath("BoostSRL.jar")
+        self.SRLBOOST_BACKEND = here.joinpath("SRLBoost.jar")
+        self.AUC_JAR = here
+        self.TRAIN_LOG = directory.joinpath("train_output.txt")
+        self.TEST_LOG = directory.joinpath("test_output.txt")
+        self.TRAIN_DIR = directory.joinpath("train")
+        self.TEST_DIR = directory.joinpath("test")
+        self.MODELS_DIR = directory.joinpath("train/models/")
+        self.BRDNS_DIR = directory.joinpath("train/models/bRDNs/")
+        self.TREES_DIR = directory.joinpath("train/models/bRDNs/Trees")
+        self.DOT_DIR = directory.joinpath("train/models/bRDNs/dotFiles")
+
+
 class FileSystem:
     """BoostSRL File System
 
@@ -133,32 +152,13 @@ class FileSystem:
         _allotment_number = self._allocate_space(_data)
         _directory = _data.joinpath("data" + str(_allotment_number))
 
-        @unique
-        class Files(Enum):
-            """Pointers to all file locations required by BoostSRL"""
-
-            DIRECTORY = _directory
-            BOOSTSRL_BACKEND = _here.joinpath("BoostSRL.jar")
-            SRLBOOST_BACKEND = _here.joinpath("SRLBoost.jar")
-            AUC_JAR = _here
-            TRAIN_LOG = _directory.joinpath("train_output.txt")
-            TEST_LOG = _directory.joinpath("test_output.txt")
-            TRAIN_DIR = _directory.joinpath("train")
-            TEST_DIR = _directory.joinpath("test")
-            MODELS_DIR = _directory.joinpath("train/models/")
-            BRDNS_DIR = _directory.joinpath("train/models/bRDNs/")
-            TREES_DIR = _directory.joinpath("train/models/bRDNs/Trees")
-            DOT_DIR = _directory.joinpath("train/models/bRDNs/dotFiles")
-
-        # Create directories
-        Files.TRAIN_DIR.value.mkdir()
-        Files.TEST_DIR.value.mkdir()
-
-        self.files = Files
+        self.files = BoostSRLFiles(_directory, _here)
+        self.files.TRAIN_DIR.mkdir()
+        self.files.TEST_DIR.mkdir()
 
     def __del__(self):
         """Clean up the file system on object de-allocation."""
-        shutil.rmtree(self.files.DIRECTORY.value)
+        shutil.rmtree(self.files.DIRECTORY)
 
     @staticmethod
     def _allocate_space(current_directory) -> int:

--- a/srlearn/tests/test_system_manager.py
+++ b/srlearn/tests/test_system_manager.py
@@ -11,7 +11,7 @@ from srlearn.system_manager import FileSystem
 def test_initialize_file_system():
     """Test initializing a FileSystem()"""
     system0 = FileSystem()
-    _location = system0.files.DIRECTORY.value
+    _location = system0.files.DIRECTORY
 
     assert _location.exists()
     del system0
@@ -23,8 +23,8 @@ def test_initialize_two_systems():
     system0 = FileSystem()
     system1 = FileSystem()
 
-    _location0 = system0.files.DIRECTORY.value
-    _location1 = system1.files.DIRECTORY.value
+    _location0 = system0.files.DIRECTORY
+    _location1 = system1.files.DIRECTORY
 
     assert _location0.exists()
     assert _location1.exists()
@@ -40,9 +40,9 @@ def test_system_train_test_dirs():
     """Test that train/test directories are created."""
     system0 = FileSystem()
 
-    _location = system0.files.DIRECTORY.value
-    _train_location = system0.files.TRAIN_DIR.value
-    _test_location = system0.files.TEST_DIR.value
+    _location = system0.files.DIRECTORY
+    _train_location = system0.files.TRAIN_DIR
+    _test_location = system0.files.TEST_DIR
 
     assert _train_location.exists()
     assert _test_location.exists()


### PR DESCRIPTION
- Extract `Files` to `BoostSRLFiles` to separate the implementation from the `FileSystem` object.
- The enum access made no sense here, I'm not sure what previous Alexander was thinking. Fix #94 

It's looking like different implementations all assume a file system exists, but files are sometimes named differently---worst case scenario this opens up the ability to implement different `Files` objects for different solver backends.