### PR TITLE
🐛 Fix `Classifier.node_size` / unshared background

### DIFF
--- a/docs/examples/plot_families.py
+++ b/docs/examples/plot_families.py
@@ -48,13 +48,13 @@ bk = Background(
         "childof(+name,+name).",
         "siblingof(+name,+name)."
     ],
-    node_size=1,
     number_of_clauses=8,
 )
 
 clf = BoostedRDNClassifier(
     background=bk,
     target="father",
+    node_size=1,
     n_estimators=5,
 )
 
@@ -106,13 +106,13 @@ bk = Background(
         "childof(+name,+name).",
         "siblingof(+name,+name)."
     ],
-    node_size=2,                # <--- Changed from 1 to 2
     number_of_clauses=8,
 )
 
 clf = BoostedRDNClassifier(
     background=bk,
     target="father",
+    node_size=2,                # <--- Changed from 1 to 2
     n_estimators=5,
 )
 

--- a/docs/source/user_guide.rst
+++ b/docs/source/user_guide.rst
@@ -72,11 +72,11 @@ to remain compatible with how
 >>> from srlearn import Background
 >>> bk = Background()
 >>> print(bk)
-setParam: nodeSize=2.
-setParam: maxTreeDepth=3.
 setParam: numOfClauses=100.
 setParam: numOfCycles=100.
 usePrologVariables: true.
+setParam: nodeSize=2.
+setParam: maxTreeDepth=3.
 <BLANKLINE>
 
 This gives us a view into some of the default parameters.
@@ -115,7 +115,7 @@ person in this fictional data set will develop cancer.
 ... )
 >>> clf = BoostedRDNClassifier()
 >>> print(clf)
-BoostedRDNClassifier(background=None, max_tree_depth=3, n_estimators=10, neg_pos_ratio=2, node_size=2, solver='BoostSRL', target='None')
+BoostedRDNClassifier(background=None, n_estimators=10, neg_pos_ratio=2, solver='BoostSRL', target='None')
 
 This pattern should begin to look familiar if you've worked with scikit-learn before.
 This classifier is built on top of
@@ -151,16 +151,16 @@ a series of trees.
 ... )
 >>> clf = BoostedRDNClassifier(background=bk, target="cancer")
 >>> clf.fit(train)
-BoostedRDNClassifier(background=setParam: nodeSize=2.
-setParam: maxTreeDepth=3.
-setParam: numOfClauses=100.
+BoostedRDNClassifier(background=setParam: numOfClauses=100.
 setParam: numOfCycles=100.
 usePrologVariables: true.
+setParam: nodeSize=2.
+setParam: maxTreeDepth=3.
 mode: friends(+person,-person).
 mode: friends(-person,+person).
 mode: cancer(+person).
 mode: smokes(+person).
-, max_tree_depth=3, n_estimators=10, neg_pos_ratio=2, node_size=2, solver='BoostSRL', target='cancer')
+, n_estimators=10, neg_pos_ratio=2, solver='BoostSRL', target='cancer')
 >>> clf.predict(test)
 array([ True,  True,  True, False, False])
 

--- a/srlearn/background.py
+++ b/srlearn/background.py
@@ -78,11 +78,11 @@ class Background:
         ...     ],
         ... )
         >>> print(bk)
-        setParam: nodeSize=2.
-        setParam: maxTreeDepth=2.
         setParam: numOfClauses=100.
         setParam: numOfCycles=100.
         usePrologVariables: true.
+        setParam: nodeSize=2.
+        setParam: maxTreeDepth=3.
         mode: cancer(+Person).
         mode: smokes(+Person).
         mode: friends(+Person,-Person).

--- a/srlearn/background.py
+++ b/srlearn/background.py
@@ -17,13 +17,12 @@ class Background:
 
     def __init__(
         self,
+        *,
         modes=None,
         ok_if_unknown=None,
         bridgers=None,
-        node_size=2,
         number_of_clauses=100,
         number_of_cycles=100,
-        max_tree_depth=3,
         recursion=False,
         line_search=False,
         use_std_logic_variables=False,
@@ -41,10 +40,6 @@ class Background:
             Okay if not known.
         bridgers : list of str (default: None)
             List of bridger predicates.
-        node_size : int, optional (default: 2)
-            Maximum number of literals in each node.
-        max_tree_depth : int, optional (default: 3)
-            Maximum number of nodes from root to leaf (height) in the tree.
         number_of_clauses : int, optional (default: 100)
             Maximum number of clauses in the tree (i.e. maximum number of leaves)
         number_of_cycles : int, optional (default: 100)
@@ -81,7 +76,6 @@ class Background:
         ...         "friends(+Person,-Person).",
         ...         "friends(-Person,+Person).",
         ...     ],
-        ...     max_tree_depth=2,
         ... )
         >>> print(bk)
         setParam: nodeSize=2.
@@ -101,11 +95,7 @@ class Background:
         >>> from srlearn import Background
         >>> from srlearn.datasets import load_toy_cancer
         >>> train, _ = load_toy_cancer()
-        >>> bk = Background(
-        ...     modes=train.modes,
-        ...     max_tree_depth=2,
-        ...     node_size=1,
-        ... )
+        >>> bk = Background(modes=train.modes)
         >>> bk.write("training/")   # doctest: +SKIP
 
         Notes
@@ -123,8 +113,6 @@ class Background:
         """
         self.modes = modes
         self.ok_if_unknown = ok_if_unknown
-        self.node_size = node_size
-        self.max_tree_depth = max_tree_depth
         self.number_of_clauses = number_of_clauses
         self.number_of_cycles = number_of_cycles
         self.line_search = line_search
@@ -134,6 +122,10 @@ class Background:
         self.load_all_libraries = load_all_libraries
         self.load_all_basic_modes = load_all_basic_modes
         self.bridgers = bridgers
+
+        # These parameters are stored in Background, but they're set in classifiers/regressors.
+        self.node_size = 2
+        self.max_tree_depth = 3
 
         # Check params are correct at the tail of initialization.
         self._check_params()
@@ -151,6 +143,7 @@ class Background:
             (self.bridgers, (list, type(None)), (), "'bridgers' should be 'None' or 'list'"),
             (self.line_search, (bool,), (), "'line_search' should be 'bool'"),
             (self.recursion, (bool,), (), "'recursion' should be 'bool'"),
+            (self.node_size, (int,), (lambda x: x >= 1,), "'node_size' should be 'int' >= 1"),
             (self.max_tree_depth, (int,), (lambda x: x >= 1,), "'max_tree_depth' should be 'int' >= 1"),
             (self.number_of_clauses, (int,), (lambda x: x >= 1,), "'number_of_clauses' should be 'int' >= 1"),
             (self.number_of_cycles, (int,), (lambda x: x >= 1,), "'number_of_cycles' should be 'int' >= 1"),

--- a/srlearn/base.py
+++ b/srlearn/base.py
@@ -41,18 +41,6 @@ class BaseBoostedRelationalModel:
 
     All that remains is to implement the specific cases of ``fit()``,
     ``predict()``, and ``predict_proba()``.
-
-    >>> from srlearn.base import BaseBoostedRelationalModel
-    >>> class BoostedRDNClassifier(BaseBoostedRelationalModel):
-    ...     def __init__(self, special_parameter=5):
-    ...         super().__init__(self)
-    ...         self.special_parameter = special_parameter
-    ...
-    >>> dn = BoostedRDNClassifier(special_parameter=8)
-    >>> print(dn)
-    BoostedRDNClassifier(special_parameter=8)
-    >>> print(dn.n_estimators)
-    10
     """
 
     def __init__(

--- a/srlearn/base.py
+++ b/srlearn/base.py
@@ -68,7 +68,7 @@ class BaseBoostedRelationalModel:
         background=None,
         target="None",
         n_estimators=10,
-        node_size=2,
+        node_size=None,
         max_tree_depth=3,
         neg_pos_ratio=2,
         solver="BoostSRL",
@@ -81,6 +81,9 @@ class BaseBoostedRelationalModel:
         self.max_tree_depth = max_tree_depth
         self.neg_pos_ratio = neg_pos_ratio
         self.solver = solver
+
+        if node_size and isinstance(background, Background):
+            self.background.node_size = node_size
 
     @classmethod
     def _get_param_names(cls):

--- a/srlearn/rdn.py
+++ b/srlearn/rdn.py
@@ -56,7 +56,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
         background=None,
         target="None",
         n_estimators=10,
-        node_size=2,
+        node_size=None,
         max_tree_depth=3,
         neg_pos_ratio=2,
         solver="BoostSRL",

--- a/srlearn/rdn.py
+++ b/srlearn/rdn.py
@@ -34,16 +34,16 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
     >>> bk = Background(modes=train.modes)
     >>> dn = BoostedRDNClassifier(background=bk, target="cancer")
     >>> dn.fit(train)
-    BoostedRDNClassifier(background=setParam: nodeSize=2.
-    setParam: maxTreeDepth=3.
-    setParam: numOfClauses=100.
+    BoostedRDNClassifier(background=setParam: numOfClauses=100.
     setParam: numOfCycles=100.
     usePrologVariables: true.
+    setParam: nodeSize=2.
+    setParam: maxTreeDepth=3.
     mode: friends(+Person,-Person).
     mode: friends(-Person,+Person).
     mode: smokes(+Person).
     mode: cancer(+Person).
-    , max_tree_depth=3, n_estimators=10, neg_pos_ratio=2, node_size=2, solver='BoostSRL', target='cancer')
+    , n_estimators=10, neg_pos_ratio=2, solver='BoostSRL', target='cancer')
     >>> dn.predict(test)
     array([ True,  True,  True, False, False])
 
@@ -365,11 +365,11 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
     >>> bk = Background(modes=train.modes)
     >>> reg = BoostedRDNRegressor(background=bk, target="medv", n_estimators=5)
     >>> reg.fit(train)
-    BoostedRDNRegressor(background=setParam: nodeSize=2.
-    setParam: maxTreeDepth=3.
-    setParam: numOfClauses=100.
+    BoostedRDNRegressor(background=setParam: numOfClauses=100.
     setParam: numOfCycles=100.
     usePrologVariables: true.
+    setParam: nodeSize=2.
+    setParam: maxTreeDepth=3.
     mode: crim(+id,#varsrim).
     mode: zn(+id,#varzn).
     mode: indus(+id,#varindus).
@@ -384,7 +384,7 @@ class BoostedRDNRegressor(BaseBoostedRelationalModel):
     mode: b(+id,#varb).
     mode: lstat(+id,#varlstat).
     mode: medv(+id).
-    , max_tree_depth=3, n_estimators=5, neg_pos_ratio=2, node_size=2, solver='BoostSRL', target='medv')
+    , n_estimators=5, neg_pos_ratio=2, solver='BoostSRL', target='medv')
     >>> reg.predict(test)   # doctest: +SKIP
     array([10.04313307 13.55804603 20.549378   18.14681934 23.9393469  10.01292162
          29.83298024 20.34668817 27.81642572 32.04067867  9.41342835 20.975001

--- a/srlearn/rdn.py
+++ b/srlearn/rdn.py
@@ -56,7 +56,7 @@ class BoostedRDNClassifier(BaseBoostedRelationalModel):
         background=None,
         target="None",
         n_estimators=10,
-        node_size=None,
+        node_size=2,
         max_tree_depth=3,
         neg_pos_ratio=2,
         solver="BoostSRL",

--- a/srlearn/tests/test_background.py
+++ b/srlearn/tests/test_background.py
@@ -66,16 +66,14 @@ def test_initializing_example_background_knowledge_2():
         modes=train.modes,
         line_search=True,
         recursion=True,
-        node_size=3,
-        max_tree_depth=4,
         number_of_clauses=8,
         number_of_cycles=10,
     )
     assert _bk.modes == train.modes
 
     _capture = str(_bk)
-    assert "setParam: nodeSize=3." in _capture
-    assert "setParam: maxTreeDepth=4." in _capture
+    assert "setParam: nodeSize=2." in _capture
+    assert "setParam: maxTreeDepth=3." in _capture
     assert "setParam: numOfCycles=10." in _capture
     assert "setParam: numOfClauses=8." in _capture
     assert "setParam: lineSearch=true." in _capture
@@ -93,8 +91,6 @@ def test_initializing_example_background_knowledge_3():
         modes=train.modes,
         line_search=True,
         recursion=True,
-        node_size=3,
-        max_tree_depth=4,
         number_of_clauses=8,
         number_of_cycles=10,
         ok_if_unknown=["smokes/1", "friends/2"],
@@ -103,8 +99,8 @@ def test_initializing_example_background_knowledge_3():
     assert _bk.modes == train.modes
 
     _capture = str(_bk)
-    assert "setParam: nodeSize=3." in _capture
-    assert "setParam: maxTreeDepth=4." in _capture
+    assert "setParam: nodeSize=2." in _capture
+    assert "setParam: maxTreeDepth=3." in _capture
     assert "setParam: numOfCycles=10." in _capture
     assert "setParam: numOfClauses=8." in _capture
     assert "setParam: lineSearch=true." in _capture
@@ -128,7 +124,7 @@ def test_write_background_to_file_1(tmpdir):
 def test_write_background_to_file_2(tmpdir):
     """Test writing Background object to a file with extra parameters."""
     train, _ = load_toy_cancer()
-    _bk = Background(modes=train.modes, node_size=1, max_tree_depth=5)
+    _bk = Background(modes=train.modes)
     _bk.write(filename="train", location=pathlib.Path(tmpdir))
     assert tmpdir.join("train_bk.txt").read() == str(_bk)
 
@@ -160,15 +156,6 @@ def test_initialize_bad_background_knowledge_line_search(test_input):
     """Incorrect line_search settings"""
     with pytest.raises(ValueError):
         _ = Background(line_search=test_input)
-
-
-@pytest.mark.parametrize(
-    "test_input", [0, -1, None, "True", "False", bool, int, 1.5, False]
-)
-def test_initialize_bad_background_knowledge_max_tree_depth(test_input):
-    """Incorrect max_tree_depth settings."""
-    with pytest.raises(ValueError):
-        _ = Background(max_tree_depth=test_input)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix #23

This fixes the bug, but since class attributes are mutable by default
it's still possible to change `node_size` in
`srlearn.rdn.BoostedRDNClassifier` without the change propagating into
a `Background` instance:

```python
from srlearn.rdn import BoostedRDNClassifier
from srlearn import Background

bk = Background(node_size=5)
clf = BoostedRDNClassifier(
  target='cancer',
  background=bk,
  node_size=7,
)

print(clf)  # <-- Shows node_size = 7

clf.node_size = 1

print(clf)  # <-- Shows node_size = 7
```

I might have to define it as a property and manually propagate the
changes if they are made. _Or_ wait until PEP 591 lands and I can
declare variables Final.