### PR TITLE
👽️ Fix intersphinx mapping to `numpy`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -80,7 +80,7 @@ html_static_path = ['_static']
 # intersphinx configuration
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "sklearn": ("https://scikit-learn.org/stable", None),
 }
 


### PR DESCRIPTION
`numpy` moved to their own domain name some time back.