### PR TITLE
Discrete Ranges in `Background` instances

### DIFF
--- a/srlearn/background.py
+++ b/srlearn/background.py
@@ -20,6 +20,7 @@ class Background:
         modes=None,
         ok_if_unknown=None,
         bridgers=None,
+        ranges=None,
         node_size=2,
         number_of_clauses=100,
         number_of_cycles=100,
@@ -41,6 +42,8 @@ class Background:
             Okay if not known.
         bridgers : list of str (default: None)
             List of bridger predicates.
+        ranges : dict of str (default: None)
+            Dict mapping object types to discrete categories
         node_size : int, optional (default: 2)
             Maximum number of literals in each node.
         max_tree_depth : int, optional (default: 3)
@@ -134,6 +137,7 @@ class Background:
         self.load_all_libraries = load_all_libraries
         self.load_all_basic_modes = load_all_basic_modes
         self.bridgers = bridgers
+        self.ranges = ranges
 
         # Check params are correct at the tail of initialization.
         self._check_params()
@@ -149,6 +153,7 @@ class Background:
             (self.modes, (list, type(None)), (), "'modes' should be 'None' or 'list"),
             (self.ok_if_unknown, (list, type(None)), (), "'ok_if_unknown' should be 'None' or 'list'"),
             (self.bridgers, (list, type(None)), (), "'bridgers' should be 'None' or 'list'"),
+            (self.ranges, (dict, type(None)), (), "'ranges' should be 'None' or 'dict'"),
             (self.line_search, (bool,), (), "'line_search' should be 'bool'"),
             (self.recursion, (bool,), (), "'recursion' should be 'bool'"),
             (self.max_tree_depth, (int,), (lambda x: x >= 1,), "'max_tree_depth' should be 'int' >= 1"),
@@ -227,7 +232,7 @@ class Background:
 
         _background = ""
         for _attr, _val in _relevant:
-            if _attr in ["modes", "ok_if_unknown", "bridgers"]:
+            if _attr in ["modes", "ok_if_unknown", "bridgers", "ranges"]:
                 pass
             else:
                 _background += _background_syntax[_attr].format(str(_val).lower())
@@ -247,6 +252,13 @@ class Background:
             if getattr(self, "bridgers"):
                 for _bridger in self.bridgers:
                     _background += "bridger: "  + _bridger + ".\n"
+        except AttributeError:
+            pass
+
+        try:
+            if getattr(self, "ranges"):
+                for _range in self.ranges:
+                    _background += f"range: {_range}={{" + ", ".join(self.ranges[_range]) + "}.\n"
         except AttributeError:
             pass
 

--- a/srlearn/tests/test_background.py
+++ b/srlearn/tests/test_background.py
@@ -118,6 +118,19 @@ def test_initializing_example_background_knowledge_3():
     assert "bridger: friends/2." in _capture
 
 
+def test_initialize_with_ranges():
+    """Test that ranges are created."""
+    _bk = Background(
+        ranges={
+            "part": ["gear", "wheel", "chain", "engine", "control_unit"],
+            "action": ["ok", "fix", "sendback"],
+        }
+    )
+    _capture = str(_bk)
+    assert "range: part={gear, wheel, chain, engine, control_unit}." in _capture
+    assert "range: action={ok, fix, sendback}." in _capture
+
+
 def test_write_background_to_file_1(tmpdir):
     """Test writing Background object to a file with default parameters."""
     _bk = Background()
@@ -241,3 +254,11 @@ def test_initialize_bad_bridgers(test_input):
     """Initialize bridgers with input that should raise an error."""
     with pytest.raises(ValueError):
         _ = Background(bridgers=test_input)
+
+@pytest.mark.parametrize(
+    "test_input", [0, -1, 1, 4, "True", "False", bool, int, 1.5, []]
+)
+def test_initialize_bad_ranges(test_input):
+    """Initialize a Background.ranges with bad data."""
+    with pytest.raises(ValueError):
+        _ = Background(ranges=test_input)


### PR DESCRIPTION
Fix #100 

Declaring:

```python
    _bk = Background(
        ranges={
            "part": ["gear", "wheel", "chain", "engine", "control_unit"],
            "action": ["ok", "fix", "sendback"],
        }
    )
```

Produces:

```prolog
range: part={gear, wheel, chain, engine, control_unit}.
range: action={ok, fix, sendback}.
```